### PR TITLE
fp-delegation without pox-delegation

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -5,9 +5,6 @@ authors = []
 telemetry = true
 cache_dir = './.cache'
 
-[[project.requirements]]
-contract_id = 'SP000000000000000000002Q6VF78.pox-2'
-
 [contracts.pox-delegation]
 path = 'contracts/pox-delegation.clar'
 clarity_version = 2

--- a/contracts/fp-delegation.clar
+++ b/contracts/fp-delegation.clar
@@ -8,11 +8,15 @@
 ;; or ask automation, friends or family to extend stacking using delegate-stack-stx.
 
 ;; Self-service function "delegate-stx" does the following:
-;; 1. Revoke delegation if necessary
-;; 2. Delegates STX
-;; 3. For first time user, stacks the caller's stx tokens for 1 cycle
-;;    For stackerd user, extends locking and if needed increases amount
+;; 1. Revoke delegation if necessary.
+;; 2. Delegates STX.
+;; 3. For first time user, stacks the caller's stx tokens for 1 cycle.
+;;    For stackerd user, extends locking and if needed increases amount.
+;;    The amount is the minimum of the balance and the delegate amount
+;;    minus some STX as buffer.
+;;    The STX buffer is left unlocked for users to call revoke-delegation.
 ;; 4. If possible, commits the pool's amount.
+;; Returns (ok true) if the aggregation commit happened, otherwise (ok false).
 
 ;; Pool operator function "delegate-stack-stx" does
 ;; step 3. (for stacked users) and 4. from "delegate-stx" for
@@ -28,21 +32,28 @@
 ;; Map of reward cycle to pox reward set index.
 ;; Reward set index gives access to the total locked stx of the pool.
 (define-map pox-addr-indices uint uint)
+;; Map of reward cyle to block height of last commit
+(define-map last-aggregation uint uint)
+;; Map of admins that can change the pox-address
+(define-map reward-admins principal bool)
+(map-set reward-admins tx-sender true)
 
-(define-data-var reward-admin principal tx-sender)
+(define-data-var active bool true)
 (define-data-var fp-pox-address {hashbytes: (buff 32), version: (buff 1)}
     {version: 0x00,
      hashbytes: 0x6d78de7b0625dfbfc16c3a8a5735f6dc3dc3f2ce})
+(define-data-var stx-buffer uint u1000000) ;; 1 STX
 
 ;; Half cycle lenght is 1050 for mainnet
 (define-constant half-cycle-length (/ (get reward-cycle-length (unwrap-panic (contract-call? 'SP000000000000000000002Q6VF78.pox-2 get-pox-info))) u2))
 
 (define-constant err-unauthorized (err u401))
+(define-constant err-forbidden (err u403))
 (define-constant err-too-early (err u500))
 (define-constant err-decrease-forbidden (err u503))
+(define-constant err-pox-address-deactivated (err u504))
 ;; Error code 9 is used by pox-2 contract
 (define-constant err-stacking-permission-denied (err u609))
-
 ;; Allowed contract-callers
 (define-map allowance-contract-callers
     { sender: principal, contract-caller: principal }
@@ -62,7 +73,7 @@
     ;; Do 3.
     (try! (as-contract (lock-delegated-stx user)))
     ;; Do 4.
-    (maybe-stack-aggregation-commit current-cycle)))
+    (ok (maybe-stack-aggregation-commit current-cycle))))
 
 ;; Stacks the delegated amount for the given user for the next cycle.
 ;; This function can be called by automation, friends or family for user that have delegated once.
@@ -73,11 +84,7 @@
     ;; Do 3.
     (try! (as-contract (lock-delegated-stx user)))
     ;; Do 4.
-    (maybe-stack-aggregation-commit current-cycle)))
-
-
-;; Context variable for delegate-stack-stx-many
-(define-data-var ctx-cycle uint u0)
+    (ok (maybe-stack-aggregation-commit current-cycle))))
 
 ;; Stacks the delegated amount for the given users for the next cycle.
 ;; This function can be called by automation, friends or family for users that have delegated once.
@@ -86,12 +93,11 @@
   (let ((current-cycle (contract-call? 'SP000000000000000000002Q6VF78.pox-2 current-pox-reward-cycle))
         (start-burn-ht (+ burn-block-height u1)))
     (asserts! (can-lock-now current-cycle) err-too-early)
-    ;; Do 3.
-    (var-set ctx-cycle current-cycle)
+    ;; Do 3. for users
     (let ((locking-result
             (as-contract (fold lock-delegated-stx-fold users (list)))))
     ;; Do 4.
-    (try! (maybe-stack-aggregation-commit current-cycle))
+    (maybe-stack-aggregation-commit current-cycle)
     (ok locking-result))))
 
 ;;
@@ -100,7 +106,6 @@
 
 ;; Revokes and delegates stx
 (define-private (delegate-stx-inner (amount-ustx uint) (delegate-to principal) (until-burn-ht (optional uint)))
-
   (let ((result-revoke
             ;; Calls revoke and ignores result
             (contract-call? 'SP000000000000000000002Q6VF78.pox-2 revoke-delegate-stx)))
@@ -114,7 +119,12 @@
 (define-private (lock-delegated-stx (user principal))
   (let ((start-burn-ht (+ burn-block-height u1))
         (pox-address (var-get fp-pox-address))
-        (amount-ustx (get-delegated-amount user)))
+        ;; delegate the minimum of the delegated amount and stx balance (including locked stx)
+        (buffer-amount (var-get stx-buffer))
+        (allowed-amount (min (get-delegated-amount user) (stx-get-balance user)))
+        (save-amount (if (> allowed-amount buffer-amount) (- allowed-amount buffer-amount) allowed-amount))
+        (amount-ustx (max save-amount (get locked (stx-account user)))))
+    (asserts! (var-get active) err-pox-address-deactivated)
     (match (contract-call? 'SP000000000000000000002Q6VF78.pox-2 delegate-stack-stx
                                 user amount-ustx
                                 pox-address start-burn-ht u1)
@@ -158,37 +168,66 @@
 (define-private (maybe-stack-aggregation-commit (current-cycle uint))
   (let ((reward-cycle (+ u1 current-cycle)))
     (match (map-get? pox-addr-indices reward-cycle)
-            ;; total stacked already reached minimum
-            index (as-bool-response-with-uint (as-contract (contract-call? 'SP000000000000000000002Q6VF78.pox-2 stack-aggregation-increase (var-get fp-pox-address) reward-cycle index)))
-            ;; total stacked below minimum
-            ;; just try to commit, it might fail because minimum not yet met
+            ;; Total stacked already reached minimum.
+            ;; Call stack-aggregate-increase.
+            ;; It might fail because called in the same cycle twice.
+            index (match (as-contract (contract-call? 'SP000000000000000000002Q6VF78.pox-2 stack-aggregation-increase (var-get fp-pox-address) reward-cycle index))
+                    success (map-set last-aggregation reward-cycle block-height)
+                    error (begin (print {err-increase-ignored: error}) false))
+            ;; Total stacked is still below minimum.
+            ;; Just try to commit, it might fail because minimum not yet met
             (match (as-contract (contract-call? 'SP000000000000000000002Q6VF78.pox-2 stack-aggregation-commit-indexed (var-get fp-pox-address) reward-cycle))
               index (begin
                       (map-set pox-addr-indices reward-cycle index)
-                      (ok true))
-              error (ok true))))) ;; ignore errors
+                      (map-set last-aggregation reward-cycle block-height))
+              error (begin (print {err-commit-ignored: error}) false))))) ;; ignore errors
 
 
 ;;
 ;; Admin functions
 ;;
 
+(define-public (set-active (is-active bool))
+  (begin
+    (asserts! (default-to false (map-get? reward-admins contract-caller)) err-unauthorized)
+    (ok (var-set active is-active))))
+
 (define-public (set-fp-pox-address (pox-addr {hashbytes: (buff 32), version: (buff 1)}))
   (begin
-    (asserts! (is-eq contract-caller (var-get reward-admin)) err-unauthorized)
+    (asserts! (default-to false (map-get? reward-admins contract-caller)) err-unauthorized)
     (ok (var-set fp-pox-address pox-addr))))
 
-(define-public (set-admin (new-admin principal))
+(define-public (set-stx-buffer (amount-ustx uint))
   (begin
-    (asserts! (is-eq contract-caller (var-get reward-admin)) err-unauthorized)
-    (ok (var-set reward-admin new-admin))))
+    (asserts! (default-to false (map-get? reward-admins contract-caller)) err-unauthorized)
+    (ok (var-set stx-buffer amount-ustx))))
+
+(define-public (set-reward-admin (new-admin principal) (enable bool))
+  (begin
+    (asserts! (default-to false (map-get? reward-admins contract-caller)) err-unauthorized)
+    (asserts! (not (is-eq contract-caller new-admin)) err-forbidden)
+    (ok (map-set reward-admins new-admin enable))))
 
 ;;
 ;; Read-only functions
 ;;
 
-(define-read-only (get-reward-set-pox-address (reward-cycle uint) (index uint))
-  (contract-call? 'SP000000000000000000002Q6VF78.pox-2 get-reward-set-pox-address reward-cycle index))
+;; Total of locked stacked by cycle.
+;; Function get-reward-set-pox-address contains the information but
+;; is deleted when stx unlock.
+;; Therefore, we look at the value at the end of that cycle, more
+;; precisely at the last stack-aggregation-* call for the next cycle (that happens
+;; during the request cycle).
+(define-read-only (get-reward-set (reward-cycle uint))
+  (match (print (map-get? last-aggregation (+ reward-cycle u1)))
+    stacks-height (get-reward-set-at-block reward-cycle stacks-height)
+    none))
+
+(define-read-only (get-reward-set-at-block (reward-cycle uint) (stacks-height uint))
+   (at-block (unwrap! (get-block-info? id-header-hash stacks-height) none)
+      (match (print (map-get? pox-addr-indices reward-cycle))
+        index (contract-call? 'SP000000000000000000002Q6VF78.pox-2 get-reward-set-pox-address reward-cycle index)
+        none)))
 
 (define-read-only (get-delegated-amount (user principal))
   (default-to u0 (get amount-ustx (contract-call? 'SP000000000000000000002Q6VF78.pox-2 get-delegation-info user))))
@@ -196,8 +235,11 @@
 (define-read-only (get-pox-addr-index (cycle uint))
   (map-get? pox-addr-indices cycle))
 
-(define-read-only (get-reward-admin)
-  (var-get reward-admin))
+(define-read-only (get-last-aggregation (cycle uint))
+  (map-get? last-aggregation cycle))
+
+(define-read-only (is-admin-enabled (admin principal))
+  (map-get? reward-admins admin))
 
 (define-read-only (get-fp-pox-address)
   (var-get fp-pox-address))
@@ -208,13 +250,25 @@
 (define-read-only (get-first-result (results (response (list 30 (response {lock-amount: uint, stacker: principal, unlock-burn-height: uint} uint)) uint)))
   (unwrap-panic (element-at (unwrap-panic results) u0)))
 
-;; converts response of type (response tuple int) to (response tuple uint)
+;; Converts response of type (response tuple int) to (response tuple uint)
 (define-read-only (as-tuple-response-with-uint (result (response {lock-amount: uint, stacker: principal, unlock-burn-height: uint} int)))
   (match result success (ok success) error (err (to-uint error))))
 
-;; converts response of type (response bool int) to (response bool uint)
+;; Converts response of type (response bool int) to (response bool uint)
 (define-read-only (as-bool-response-with-uint (result (response bool int)))
   (match result success (ok success) error (err (to-uint error))))
+
+;; Returns minimum
+(define-private (min (amount-1 uint) (amount-2 uint))
+  (if (< amount-1 amount-2)
+    amount-1
+    amount-2))
+
+;; Returns maximum
+(define-private (max (amount-1 uint) (amount-2 uint))
+  (if (> amount-1 amount-2)
+    amount-1
+    amount-2))
 
 ;;
 ;; Functions about alloance of delegation/stacking contract calls

--- a/contracts/helper.clar
+++ b/contracts/helper.clar
@@ -4,5 +4,10 @@
 (define-public (get-stx-account (user principal))
   (ok (print (contract-call? .pox-delegation get-stx-account user))))
 
+(define-public (get-reward-set (reward-cycle uint))
+  (ok (print (contract-call? .fp-delegation get-reward-set reward-cycle))))
+
+;; call wrapper contract from a contract
+;; requires allowance
 (define-public (delegate-stx (amount-ustx uint))
   (contract-call? .fp-delegation delegate-stx amount-ustx))

--- a/contracts/pox-delegation.clar
+++ b/contracts/pox-delegation.clar
@@ -126,7 +126,7 @@
         (amount-ustx (min (get amount-ustx details) (stx-get-balance user))))
       (let
         ((stack-result
-          ;; call revoke and delegate-stack-stx
+          ;; call delegate-stack-stx
           (if (> amount-ustx u0)
             (match (map-get? user-data user)
               user-details (match (contract-call? 'SP000000000000000000002Q6VF78.pox-2 delegate-stack-stx

--- a/deployments/default.devnet-plan.yaml
+++ b/deployments/default.devnet-plan.yaml
@@ -9,29 +9,23 @@ plan:
     - id: 0
       transactions:
         - contract-publish:
-            contract-name: pox-delegation
+            contract-name: fp-delegation
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            remap-principals:
-              SP000000000000000000002Q6VF78: ST000000000000000000002AMW42H
-            cost: 119980
-            path: contracts/pox-delegation.clar
+            cost: 149140
+            path: contracts/fp-delegation.clar
             anchor-block-only: true
             clarity-version: 2
         - contract-publish:
-            contract-name: fp-delegation
+            contract-name: pox-delegation
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            remap-principals:
-              SP000000000000000000002Q6VF78: ST000000000000000000002AMW42H
-            cost: 23620
-            path: contracts/fp-delegation.clar
+            cost: 145350
+            path: contracts/pox-delegation.clar
             anchor-block-only: true
             clarity-version: 2
         - contract-publish:
             contract-name: helper
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            remap-principals:
-              SP000000000000000000002Q6VF78: ST000000000000000000002AMW42H
-            cost: 2370
+            cost: 5390
             path: contracts/helper.clar
             anchor-block-only: true
             clarity-version: 2

--- a/deployments/fp-0-allow-contract-caller.devnet-plan.yaml
+++ b/deployments/fp-0-allow-contract-caller.devnet-plan.yaml
@@ -1,0 +1,27 @@
+---
+id: 0
+name: Devnet deployment
+network: devnet
+stacks-node: "http://localhost:20443"
+bitcoin-node: "http://devnet:devnet@localhost:18443"
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - contract-call:
+            contract-id: ST000000000000000000002AMW42H.pox-2
+            expected-sender: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+            method: allow-contract-caller
+            parameters:
+              - "'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.fp-delegation"
+              - none
+            cost: 10000
+        - contract-call:
+            contract-id: ST000000000000000000002AMW42H.pox-2
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            method: allow-contract-caller
+            parameters:
+              - "'ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.fp-delegation"
+              - none
+            cost: 10000
+      epoch: "2.1"

--- a/deployments/fp-2a-delegate-stack.yaml
+++ b/deployments/fp-2a-delegate-stack.yaml
@@ -9,24 +9,24 @@ plan:
     - id: 0
       transactions:
         - contract-call:
-            contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.helper
+            contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.fp-delegation
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            method: get-reward-set
+            method: delegate-stack-stx
             parameters:
-              - u1
+              - "'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5"
             cost: 10000
         - contract-call:
             contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.helper
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            method: get-reward-set
+            method: get-user-data
             parameters:
-              - u2
+              - "'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5"
             cost: 10000
         - contract-call:
             contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.helper
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            method: get-reward-set
+            method: get-stx-account
             parameters:
-              - u3
+              - "'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5"
             cost: 10000
       epoch: "2.1"

--- a/deployments/fp-2b-delegate-stack-many.yaml
+++ b/deployments/fp-2b-delegate-stack-many.yaml
@@ -11,10 +11,9 @@ plan:
         - contract-call:
             contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.fp-delegation
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            method: delegate-stack-stx
+            method: delegate-stack-stx-many
             parameters:
-              - u2300000000000
-              - "'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5"
+              - "(list 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5)"
             cost: 10000
         - contract-call:
             contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.helper

--- a/tests/client/fp-delegation-client.ts
+++ b/tests/client/fp-delegation-client.ts
@@ -1,6 +1,5 @@
 import { Chain, Tx, types, Account } from "../deps.ts";
 
-
 export function fpDelegationAllowContractCaller(
   contractCaller: string,
   untilBurnHt: number | undefined,
@@ -27,14 +26,22 @@ export function delegateStx(amount: number, user: Account) {
 }
 
 export function delegateStackStx(
-  amountUstx: number,
   stacker: Account,
   user: Account
 ) {
   return Tx.contractCall(
     "fp-delegation",
     "delegate-stack-stx",
-    [types.uint(amountUstx), types.principal(stacker.address)],
+    [types.principal(stacker.address)],
+    user.address
+  );
+}
+
+export function delegateStackStxMany(stackers: Account[], user: Account) {
+  return Tx.contractCall(
+    "fp-delegation",
+    "delegate-stack-stx-many",
+    [types.list(stackers.map((s) => types.principal(s.address)))],
     user.address
   );
 }

--- a/tests/client/pox-2-client.ts
+++ b/tests/client/pox-2-client.ts
@@ -58,11 +58,21 @@ export function getPartialStackedByCycle(
   );
 }
 
-
-export function getPoxInfo(
+export function getRewardSetPoxAddress(
+  cycle: number,
+  index: number,
   chain: Chain,
   user: Account
 ) {
+  return chain.callReadOnlyFn(
+    "SP000000000000000000002Q6VF78.pox-2",
+    "get-reward-set-pox-address",
+    [types.uint(cycle), types.uint(index)],
+    user.address
+  );
+}
+
+export function getPoxInfo(chain: Chain, user: Account) {
   return chain.callReadOnlyFn(
     "SP000000000000000000002Q6VF78.pox-2",
     "get-pox-info",

--- a/tests/fp-delegation_allowance_test.ts
+++ b/tests/fp-delegation_allowance_test.ts
@@ -63,6 +63,6 @@ Clarinet.test({
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
-    expectTotalStackedByCycle(1, 0, 20_000_000_000_000, chain, deployer);
+    expectTotalStackedByCycle(1, 0, 19_999_999_000_000, chain, deployer);
   },
 });

--- a/tests/fp-delegation_allowance_test.ts
+++ b/tests/fp-delegation_allowance_test.ts
@@ -6,6 +6,7 @@ import {
 import { Clarinet, Chain, Account, Tx, types } from "./deps.ts";
 import { Errors, PoxErrors } from "./constants.ts";
 import { poxDelegationAllowContractCaller } from "./client/pox-delegation-client.ts";
+import { expectTotalStackedByCycle } from "./utils.ts";
 
 Clarinet.test({
   name: "Ensure that user can't delegate without allowance",
@@ -13,7 +14,6 @@ Clarinet.test({
     const deployer = accounts.get("deployer")!;
     const wallet_1 = accounts.get("wallet_1")!;
     const wallet_2 = accounts.get("wallet_2")!;
-    const poxDelegationContract = deployer.address + ".pox-delegation";
     const fpDelegationContract = deployer.address + ".fp-delegation";
 
     // try without any allowance
@@ -22,37 +22,12 @@ Clarinet.test({
     // check delegation calls
     block.receipts[0].result
       .expectErr()
-      .expectUint(Errors.StackingPermissionDenied);
-
-    // try with pox delegation allowance only
-    block = chain.mineBlock([
-      poxDelegationAllowContractCaller(
-        fpDelegationContract,
-        undefined,
-        wallet_1
-      ),
-      delegateStx(20_000_000_000_000, wallet_1),
-    ]);
-
-    block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result
-      .expectErr()
-      .expectUint(PoxErrors.StackingPermissionDenied * 1000);
-
-    // try with pox allowance only
-    block = chain.mineBlock([
-      allowContractCaller(poxDelegationContract, undefined, wallet_2),
-      delegateStx(20_000_000_000_000, wallet_2),
-    ]);
-    block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result
-      .expectErr()
-      .expectUint(Errors.StackingPermissionDenied);
+      .expectUint(PoxErrors.StackingPermissionDenied * 1_000);
   },
 });
 
 Clarinet.test({
-  name: "Ensure that user can only delegate from a contract with three allowances",
+  name: "Ensure that user can only delegate from a contract with two allowances",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     const helperDelegateStx = (amountUstx: number, user: Account) => {
       return Tx.contractCall(
@@ -65,34 +40,21 @@ Clarinet.test({
     const deployer = accounts.get("deployer")!;
     const wallet_1 = accounts.get("wallet_1")!;
     const wallet_2 = accounts.get("wallet_2")!;
-    const poxDelegationContract = deployer.address + ".pox-delegation";
     const fpDelegationContract = deployer.address + ".fp-delegation";
     const helperContract = deployer.address + ".helper";
 
     // try without any allowance
     let block = chain.mineBlock([helperDelegateStx(20_000_000_000, wallet_1)]);
-    block.receipts[0].result.expectErr().expectUint(709);
-
-    // try with additional pox allowance
-    block = chain.mineBlock([
-      allowContractCaller(poxDelegationContract, undefined, wallet_1),
-      helperDelegateStx(20_000_000_000_000, wallet_1),
-    ]);
-    block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectErr().expectUint(709);
+    block.receipts[0].result.expectErr().expectUint(609);
 
     // try with pox delegation allowance only
     block = chain.mineBlock([
-      poxDelegationAllowContractCaller(
-        fpDelegationContract,
-        undefined,
-        wallet_1
-      ),
+      allowContractCaller(fpDelegationContract, undefined, wallet_1),
       helperDelegateStx(20_000_000_000_000, wallet_1),
     ]);
 
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectErr().expectUint(709);
+    block.receipts[1].result.expectErr().expectUint(609);
 
     // delegate-stx with all allowances
     block = chain.mineBlock([
@@ -100,6 +62,7 @@ Clarinet.test({
       helperDelegateStx(20_000_000_000_000, wallet_1),
     ]);
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectUint(20_000_000_000_000);
+    block.receipts[1].result.expectOk().expectBool(true);
+    expectTotalStackedByCycle(1, 0, 20_000_000_000_000, chain, deployer);
   },
 });

--- a/tests/fp-delegation_pool_operator_many_test.ts
+++ b/tests/fp-delegation_pool_operator_many_test.ts
@@ -51,16 +51,16 @@ Clarinet.test({
     let block = chain.mineBlock([
       allowContractCaller(fpDelegationContract, undefined, wallet_1),
       allowContractCaller(fpDelegationContract, undefined, wallet_2),
-      delegateStx(2_000_000, wallet_1),
-      delegateStx(2_000_000, wallet_2),
+      delegateStx(20_000_000, wallet_1),
+      delegateStx(20_000_000, wallet_2),
     ]);
 
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
-    block.receipts[2].result.expectOk().expectBool(true);
-    block.receipts[3].result.expectOk().expectBool(true);
+    block.receipts[2].result.expectOk().expectBool(false);
+    block.receipts[3].result.expectOk().expectBool(false);
 
-    expectPartialStackedByCycle(poxAddrFP, 1, 4_000_000, chain, deployer);
+    expectPartialStackedByCycle(poxAddrFP, 1, 38_000_000, chain, deployer);
     expectTotalStackedByCycle(1, 0, undefined, chain, deployer);
 
     chain.mineEmptyBlock(3200);
@@ -101,9 +101,9 @@ Clarinet.test({
     ]);
 
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[1].result.expectOk().expectBool(false);
 
-    expectPartialStackedByCycle(poxAddrFP, 1, 2_000_000, chain, deployer);
+    expectPartialStackedByCycle(poxAddrFP, 1, 1_000_000, chain, deployer);
     expectPartialStackedByCycle(poxAddrFP, 2, undefined, chain, deployer);
 
     // advance to middle of next cycle

--- a/tests/fp-delegation_pool_operator_many_test.ts
+++ b/tests/fp-delegation_pool_operator_many_test.ts
@@ -2,6 +2,7 @@ import { allowContractCaller } from "./client/pox-2-client.ts";
 import {
   delegateStx,
   delegateStackStx,
+  delegateStackStxMany,
 } from "./client/fp-delegation-client.ts";
 import { Clarinet, Chain, Account, assertEquals } from "./deps.ts";
 import { expectPartialStackedByCycle } from "./utils.ts";
@@ -10,7 +11,7 @@ import { poxDelegationAllowContractCaller } from "./client/pox-delegation-client
 import { expectTotalStackedByCycle } from "./utils.ts";
 
 Clarinet.test({
-  name: "Ensure that users can delegate",
+  name: "Ensure that user can lock for others",
   async fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const wallet_1 = accounts.get("wallet_1")!;
@@ -32,9 +33,7 @@ Clarinet.test({
     block.receipts[2].result.expectOk().expectBool(true);
     block.receipts[3].result.expectOk().expectBool(true);
 
-    expectPartialStackedByCycle(poxAddrFP, 1, undefined, chain, deployer);
-    expectTotalStackedByCycle(1, 0, 20_000_002_000_000, chain, deployer);
-
+    delegateStackStxMany([wallet_1, wallet_2], deployer);
   },
 });
 
@@ -43,31 +42,46 @@ Clarinet.test({
   async fn(chain: Chain, accounts: Map<string, Account>) {
     const deployer = accounts.get("deployer")!;
     const wallet_1 = accounts.get("wallet_1")!;
+    const wallet_2 = accounts.get("wallet_2")!;
+
     const fpDelegationContract = deployer.address + ".fp-delegation";
     // current cycle is cycle 0
 
     // delegate 2 stx for cycle 1
     let block = chain.mineBlock([
       allowContractCaller(fpDelegationContract, undefined, wallet_1),
+      allowContractCaller(fpDelegationContract, undefined, wallet_2),
       delegateStx(2_000_000, wallet_1),
+      delegateStx(2_000_000, wallet_2),
     ]);
 
     block.receipts[0].result.expectOk().expectBool(true);
     block.receipts[1].result.expectOk().expectBool(true);
-    console.log(block.receipts[1].events);
+    block.receipts[2].result.expectOk().expectBool(true);
+    block.receipts[3].result.expectOk().expectBool(true);
 
-    expectPartialStackedByCycle(poxAddrFP, 1, 2_000_000, chain, deployer);
+    expectPartialStackedByCycle(poxAddrFP, 1, 4_000_000, chain, deployer);
     expectTotalStackedByCycle(1, 0, undefined, chain, deployer);
 
-    chain.mineEmptyBlock(2100);
+    chain.mineEmptyBlock(3200);
 
     // increase delegation to 3 stx for cycle 2
-    block = chain.mineBlock([delegateStx(3_000_000, wallet_1)]);
+    block = chain.mineBlock([
+      delegateStackStxMany([wallet_1, wallet_2], deployer),
+    ]);
 
     // support for simnet is limited, in particular stx-account returns other values
     // therefore, delegate-stack-stx fails as stx-account locked amount returns 0.
-    // block.receipts[0].result.expectOk().expectUint(3_000_000);
+    // block.receipts[0].result.expectOk().expectList()[0].expectOk().expectTuple();
+    // block.receipts[1].result.expectOk().expectList()[0].expectOk().expectTuple();
     block.receipts[0].result
+      .expectOk()
+      .expectList()[0]
+      .expectErr()
+      .expectUint(PoxErrors.StackExtendNotLocked * 1_000_000);
+      block.receipts[0].result
+      .expectOk()
+      .expectList()[1]
       .expectErr()
       .expectUint(PoxErrors.StackExtendNotLocked * 1_000_000);
   },
@@ -95,12 +109,12 @@ Clarinet.test({
     // advance to middle of next cycle
     block = chain.mineEmptyBlock(3149);
     // try to extend to cycle 2 early
-    block = chain.mineBlock([delegateStackStx( wallet_1, wallet_2)]);
+    block = chain.mineBlock([delegateStackStx(wallet_1, wallet_2)]);
     assertEquals(block.height, 3152);
     block.receipts[0].result.expectErr().expectUint(FpErrors.TooEarly);
 
     // extend to cycle 2
-    block = chain.mineBlock([delegateStackStx( wallet_1, wallet_2)]);
+    block = chain.mineBlock([delegateStackStx(wallet_1, wallet_2)]);
     expectPartialStackedByCycle(poxAddrFP, 2, undefined, chain, deployer);
 
     // support for simnet is limited, in particular stx-account returns other values

--- a/tests/fp-delegation_test.ts
+++ b/tests/fp-delegation_test.ts
@@ -21,8 +21,8 @@ Clarinet.test({
       allowContractCaller(fpDelegationContract, undefined, wallet_1),
       allowContractCaller(fpDelegationContract, undefined, wallet_2),
 
-      delegateStx(20_000_000_000_000, wallet_1),
-      delegateStx(2_000_000, wallet_2),
+      delegateStx(20_000_000_000_100, wallet_1),
+      delegateStx(2_100_000, wallet_2),
     ]);
 
     // check allow contract caller
@@ -33,7 +33,7 @@ Clarinet.test({
     block.receipts[3].result.expectOk().expectBool(true);
 
     expectPartialStackedByCycle(poxAddrFP, 1, undefined, chain, deployer);
-    expectTotalStackedByCycle(1, 0, 20_000_002_000_000, chain, deployer);
+    expectTotalStackedByCycle(1, 0, 20_000_000_100_100, chain, deployer);
 
   },
 });
@@ -53,10 +53,10 @@ Clarinet.test({
     ]);
 
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[1].result.expectOk().expectBool(false);
     console.log(block.receipts[1].events);
 
-    expectPartialStackedByCycle(poxAddrFP, 1, 2_000_000, chain, deployer);
+    expectPartialStackedByCycle(poxAddrFP, 1, 1_000_000, chain, deployer);
     expectTotalStackedByCycle(1, 0, undefined, chain, deployer);
 
     chain.mineEmptyBlock(2100);
@@ -87,9 +87,9 @@ Clarinet.test({
     ]);
 
     block.receipts[0].result.expectOk().expectBool(true);
-    block.receipts[1].result.expectOk().expectBool(true);
+    block.receipts[1].result.expectOk().expectBool(false);
 
-    expectPartialStackedByCycle(poxAddrFP, 1, 2_000_000, chain, deployer);
+    expectPartialStackedByCycle(poxAddrFP, 1, 1_000_000, chain, deployer);
     expectPartialStackedByCycle(poxAddrFP, 2, undefined, chain, deployer);
 
     // advance to middle of next cycle

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,5 +1,8 @@
 import { Account, Chain } from "./deps.ts";
-import { getPartialStackedByCycle } from "./client/pox-2-client.ts";
+import {
+  getPartialStackedByCycle,
+  getRewardSetPoxAddress,
+} from "./client/pox-2-client.ts";
 import { poxAddrPool1 } from "./constants.ts";
 
 export function expectPartialStackedByCycle(
@@ -18,6 +21,21 @@ export function expectPartialStackedByCycle(
   ).result;
   if (amountUstx) {
     result.expectSome().expectTuple()["stacked-amount"].expectUint(amountUstx);
+  } else {
+    result.expectNone();
+  }
+}
+
+export function expectTotalStackedByCycle(
+  cycle: number,
+  index: number,
+  amountUstx: number,
+  chain: Chain,
+  user: Account
+) {
+  const result = getRewardSetPoxAddress(cycle, index, chain, user).result;
+  if (amountUstx) {
+    result.expectSome().expectTuple()["total-ustx"].expectUint(amountUstx);
   } else {
     result.expectNone();
   }


### PR DESCRIPTION
This PR
* removes dependency of fp-delegation contract from pox-delegation contract. fp-delegation uses pox-2 directly