### PR TITLE
Only 1 locking cycle

### DIFF
--- a/contracts/pox-delegation.clar
+++ b/contracts/pox-delegation.clar
@@ -85,12 +85,12 @@
 (define-private (map-set-details (pool principal) (details {lock-amount: uint, stacker: principal, unlock-burn-height: uint, pox-addr: (tuple (hashbytes (buff 32)) (version (buff 1))), cycle: uint}))
   (let ((reward-cycle (+ (contract-call? 'SP000000000000000000002Q6VF78.pox-2 current-pox-reward-cycle) u1))
         (last-index (get-status-lists-last-index pool reward-cycle))
-        (key {pool: pool, reward-cycle: reward-cycle, index: last-index}))
-      (match (map-get? grouped-stackers key)
+        (stacker-key {pool: pool, reward-cycle: reward-cycle, index: last-index}))
+      (match (map-get? grouped-stackers stacker-key)
         stackers (match (as-max-len? (append stackers details) u30)
-                updated-list (map-set grouped-stackers key updated-list)
+                updated-list (map-set grouped-stackers stacker-key updated-list)
                 (insert-in-new-list pool reward-cycle last-index details))
-        (map-insert grouped-stackers key (list details)))
+        (map-insert grouped-stackers stacker-key (list details)))
       (map-set grouped-totals {pool: pool, reward-cycle: reward-cycle} (+ (get-total pool reward-cycle) (get lock-amount details)))))
 
 ;; calls pox-2 delegate-stack-extend and delegate-stack-increase.

--- a/contracts/pox-delegation.clar
+++ b/contracts/pox-delegation.clar
@@ -195,7 +195,7 @@
         (fold pox-delegate-stack-stx users {start-burn-ht: start-burn-ht, pox-address: pox-address, result: (list)})))
       (err u1))) ;; defines uint as error type
 
-;; Pool admins call this function to lock stacks of their pool members in batches
+;; Pool admins call this function to lock stacks of their pool members in batches for a lock period of 1 cycle
 (define-public (delegate-stack-stx-simple (users (list 30 principal))
                                     (pox-address { version: (buff 1), hashbytes: (buff 32) })
                                     (start-burn-ht uint))

--- a/deployments/2a-delegate-stack.devnet-plan.yaml
+++ b/deployments/2a-delegate-stack.devnet-plan.yaml
@@ -13,9 +13,9 @@ plan:
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
             method: delegate-stack-stx
             parameters:
-              - "(list {amount-ustx: u2200000000000, user: 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5})"
-              - "{version: 0x00, hashbytes: 0x6d78de7b0625dfbfc16c3a8a5735f6dc3dc3f2ce}"
-              - u133
+              - "(list {amount-ustx: u220000000000000, user: 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5})"
+              - "{version: 0x05, hashbytes: 0x6d78de7b0625dfbfc16c3a8a5735f6dc3dc3f2ce}"
+              - u129
               - u1
             cost: 10000
         - contract-call:

--- a/deployments/2b-delegate-stack-simple.devnet-plan.yaml
+++ b/deployments/2b-delegate-stack-simple.devnet-plan.yaml
@@ -1,0 +1,36 @@
+---
+id: 0
+name: Devnet deployment
+network: devnet
+stacks-node: "http://localhost:20443"
+bitcoin-node: "http://devnet:devnet@localhost:18443"
+plan:
+  batches:
+    - id: 0
+      transactions:
+        - contract-call:
+            contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.pox-delegation
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            method: delegate-stack-stx-simple
+            parameters:
+              - "(list 'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5}"
+              - "{version: 0x05, hashbytes: 0x6d78de7b0625dfbfc16c3a8a5735f6dc3dc3f2ce}"
+              - u129
+              - u1
+            cost: 10000
+        - contract-call:
+            contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.helper
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            method: get-user-data
+            parameters:
+              - "'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5"
+            cost: 10000
+        - contract-call:
+            contract-id: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM.helper
+            expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+            method: get-stx-account
+            parameters:
+              - "'ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5"
+            cost: 10000
+
+      epoch: "2.1"

--- a/deployments/default.devnet-plan.yaml
+++ b/deployments/default.devnet-plan.yaml
@@ -11,22 +11,22 @@ plan:
         - contract-publish:
             contract-name: fp-delegation
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            cost: 149140
+            cost: 151780
             path: contracts/fp-delegation.clar
             anchor-block-only: true
             clarity-version: 2
         - contract-publish:
             contract-name: pox-delegation
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            cost: 145350
+            cost: 163280
             path: contracts/pox-delegation.clar
             anchor-block-only: true
             clarity-version: 2
         - contract-publish:
             contract-name: helper
             expected-sender: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
-            cost: 5390
-            path: contracts/helper.clar
+            cost: 7410
+            path: contracts/testing/helper.clar
             anchor-block-only: true
             clarity-version: 2
       epoch: "2.1"

--- a/tests/client/pox-delegation-client.ts
+++ b/tests/client/pox-delegation-client.ts
@@ -22,7 +22,6 @@ export function delegateStx(
   untilBurnHt: number | undefined,
   poolPoxAddr: { version: string; hashbytes: string } | undefined,
   userPoxAddr: { version: string; hashbytes: string },
-  lockingPeriod: number,
   user: Account
 ) {
   return Tx.contractCall(
@@ -34,7 +33,6 @@ export function delegateStx(
       untilBurnHt ? types.some(types.uint(untilBurnHt)) : types.none(),
       poolPoxAddr ? types.some(types.tuple(poolPoxAddr)) : types.none(),
       types.tuple(userPoxAddr),
-      types.uint(lockingPeriod),
     ],
     user.address
   );
@@ -44,7 +42,6 @@ export function delegateStackStx(
   members: { user: Account; amountUstx: number }[],
   poolPoxAddr: { version: string; hashbytes: string },
   startBurnHt: number,
-  lockingPeriod: number,
   poolOperator: Account
 ) {
   return Tx.contractCall(
@@ -62,7 +59,6 @@ export function delegateStackStx(
 
       types.tuple(poolPoxAddr),
       types.uint(startBurnHt),
-      types.uint(lockingPeriod),
     ],
     poolOperator.address
   );
@@ -72,7 +68,6 @@ export function delegateStackStxSimple(
   members: Account[],
   poolPoxAddr: { version: string; hashbytes: string },
   startBurnHt: number,
-  lockingPeriod: number,
   poolOperator: Account
 ) {
   return Tx.contractCall(
@@ -82,7 +77,6 @@ export function delegateStackStxSimple(
       types.list(members.map((u) => types.principal(u.address))),
       types.tuple(poolPoxAddr),
       types.uint(startBurnHt),
-      types.uint(lockingPeriod),
     ],
     poolOperator.address
   );
@@ -90,7 +84,6 @@ export function delegateStackStxSimple(
 export function getStatusListsLastIndex(
   poolAddress: string,
   cycle: number,
-  lockingPeriod: number,
   chain: Chain,
   user: Account
 ) {
@@ -100,7 +93,6 @@ export function getStatusListsLastIndex(
     [
       types.principal(poolAddress),
       types.uint(cycle),
-      types.uint(lockingPeriod),
     ],
     user.address
   );
@@ -109,7 +101,6 @@ export function getStatusListsLastIndex(
 export function getStatusList(
   poolAddress: string,
   cycle: number,
-  lockingPeriod: number,
   index: number,
   chain: Chain,
   user: Account
@@ -120,7 +111,6 @@ export function getStatusList(
     [
       types.principal(poolAddress),
       types.uint(cycle),
-      types.uint(lockingPeriod),
       types.uint(index),
     ],
     user.address
@@ -130,7 +120,6 @@ export function getStatusList(
 export function getTotal(
   poolAddress: string,
   cycle: number,
-  lockingPeriod: number,
   chain: Chain,
   user: Account
 ) {
@@ -140,7 +129,6 @@ export function getTotal(
     [
       types.principal(poolAddress),
       types.uint(cycle),
-      types.uint(lockingPeriod),
     ],
     user.address
   );

--- a/tests/pox-delegate_70_users_test.ts
+++ b/tests/pox-delegate_70_users_test.ts
@@ -73,7 +73,6 @@ Clarinet.test({
           undefined,
           undefined,
           btcAddrWallet1,
-          1,
           user
         )
       )
@@ -88,7 +87,6 @@ Clarinet.test({
         undefined,
         undefined,
         btcAddrWallet1,
-        1,
         wallet_1
       ),
     ]);
@@ -107,7 +105,6 @@ Clarinet.test({
           hashbytes: "0xb0b75f408a29c271d107e05d614d0ff439813d02",
         },
         40,
-        1,
         deployer
       ),
       delegateStackStx(
@@ -122,7 +119,6 @@ Clarinet.test({
           hashbytes: "0xb0b75f408a29c271d107e05d614d0ff439813d02",
         },
         40,
-        1,
         deployer
       ),
       delegateStackStx(
@@ -137,7 +133,6 @@ Clarinet.test({
           hashbytes: "0xb0b75f408a29c271d107e05d614d0ff439813d02",
         },
         40,
-        1,
         deployer
       ),
       delegateStackStx(
@@ -152,14 +147,13 @@ Clarinet.test({
           hashbytes: "0xb0b75f408a29c271d107e05d614d0ff439813d02",
         },
         40,
-        1,
         deployer
       ),
     ]);
     block.receipts.map((r: any) => r.result.expectOk());
 
     // verify total
-    const total = getTotal(deployer.address, 1, 1, chain, deployer)
+    const total = getTotal(deployer.address, 1, chain, deployer)
     total.result.expectUint(10_000_070_000_000);
   },
 });

--- a/tests/pox-delegate_flow_simple_test.ts
+++ b/tests/pox-delegate_flow_simple_test.ts
@@ -28,7 +28,6 @@ Clarinet.test({
         6300,
         undefined,
         btcAddrWallet1,
-        2,
         wallet_1
       ),
 
@@ -38,7 +37,6 @@ Clarinet.test({
         undefined,
         undefined,
         btcAddrWallet2,
-        2,
         wallet_2
       ),
 
@@ -46,7 +44,6 @@ Clarinet.test({
         [wallet_1, wallet_2],
         poxAddrPool1,
         40,
-        2,
         deployer
       ),
     ]);

--- a/tests/pox-delegate_flow_test.ts
+++ b/tests/pox-delegate_flow_test.ts
@@ -211,7 +211,6 @@ Clarinet.test({
         4200,
         undefined,
         btcAddrWallet1,
-        1,
         wallet_1
       ),
 
@@ -221,7 +220,6 @@ Clarinet.test({
         undefined,
         undefined,
         btcAddrWallet2,
-        2,
         wallet_2
       ),
     ]);
@@ -253,7 +251,6 @@ Clarinet.test({
         ],
         poxAddrPool1,
         40,
-        1,
         deployer
       ),
     ]);

--- a/tests/pox-delegate_flow_test.ts
+++ b/tests/pox-delegate_flow_test.ts
@@ -36,7 +36,6 @@ Clarinet.test({
         6300,
         undefined,
         btcAddrWallet1,
-        2,
         wallet_1
       ),
 
@@ -46,7 +45,6 @@ Clarinet.test({
         undefined,
         undefined,
         btcAddrWallet2,
-        2,
         wallet_2
       ),
 
@@ -63,7 +61,6 @@ Clarinet.test({
         ],
         poxAddrPool1,
         40,
-        2,
         deployer
       ),
     ]);
@@ -81,12 +78,12 @@ Clarinet.test({
     lockingInfoList[0]
       .expectOk()
       .expectTuple()
-      ["unlock-burn-height"].expectUint(6300);
+      ["unlock-burn-height"].expectUint(4200);
 
     lockingInfoList[1]
       .expectOk()
       .expectTuple()
-      ["unlock-burn-height"].expectUint(6300);
+      ["unlock-burn-height"].expectUint(4200);
 
     // commit for cycle 1
     block = chain.mineBlock([
@@ -117,7 +114,6 @@ Clarinet.test({
         4200,
         undefined,
         btcAddrWallet1,
-        1,
         wallet_1
       ),
 
@@ -127,7 +123,6 @@ Clarinet.test({
         undefined,
         undefined,
         btcAddrWallet2,
-        2,
         wallet_2
       ),
     ]);
@@ -161,7 +156,6 @@ Clarinet.test({
         ],
         poxAddrPool1,
         40,
-        1,
         deployer
       ),
     ]);
@@ -187,7 +181,6 @@ Clarinet.test({
         ],
         poxAddrPool1,
         40,
-        1,
         deployer
       ),
     ]);
@@ -216,7 +209,6 @@ Clarinet.test({
         undefined,
         undefined,
         btcAddrWallet1,
-        1,
         wallet_1
       ),
 
@@ -229,7 +221,6 @@ Clarinet.test({
         ],
         poxAddrPool1,
         40,
-        1,
         deployer
       ),
     ]);
@@ -253,7 +244,6 @@ Clarinet.test({
         undefined,
         undefined,
         btcAddrWallet1,
-        1,
         wallet_1
       ),
     ]);
@@ -270,7 +260,6 @@ Clarinet.test({
         ],
         poxAddrPool1,
         40,
-        1,
         deployer
       ),
     ]);
@@ -315,7 +304,6 @@ Clarinet.test({
         ],
         poxAddrPool1,
         block.block_height + 10,
-        1,
         deployer
       ),
     ]);

--- a/tests/pox-delegate_many_test.ts
+++ b/tests/pox-delegate_many_test.ts
@@ -17,6 +17,7 @@ import {
   poxAddrPool1,
   poxAddrPool2,
 } from "./constants.ts";
+import { hexToBytes } from "https://esm.sh/@stacks/common";
 
 function delegateAndDelegateStx(
   chain: Chain,
@@ -42,7 +43,6 @@ function delegateAndDelegateStx(
       4300,
       undefined,
       btcAddrWallet1,
-      1,
       wallet_1
     ),
 
@@ -52,7 +52,6 @@ function delegateAndDelegateStx(
       undefined,
       undefined,
       btcAddrWallet2,
-      2,
       wallet_2
     ),
 
@@ -66,7 +65,6 @@ function delegateAndDelegateStx(
       ],
       poxAddrPool1,
       40,
-      1,
       pool_1
     ),
 
@@ -80,7 +78,6 @@ function delegateAndDelegateStx(
       ],
       samePoxAddr ? poxAddrPool1 : poxAddrPool2,
       40,
-      2,
       pool_2
     ),
   ]);
@@ -105,7 +102,7 @@ function delegateAndDelegateStx(
   lockingInfoList[0]
     .expectOk()
     .expectTuple()
-    ["unlock-burn-height"].expectUint(6300);
+    ["unlock-burn-height"].expectUint(4200);
 }
 
 Clarinet.test({
@@ -129,62 +126,17 @@ Clarinet.test({
     block.receipts[1].result.expectOk().expectBool(true);
 
     // verify status for users with locking period 1
-    let lockingPeriod = 1;
-    let response = getStatusListsLastIndex(
-      pool_1.address,
-      1,
-      lockingPeriod,
-      chain,
-      pool_1
-    );
+    let response = getStatusListsLastIndex(pool_1.address, 1, chain, pool_1);
     response.result.expectUint(0);
 
-    response = getStatusList(
-      pool_1.address,
-      1,
-      lockingPeriod,
-      0,
-      chain,
-      pool_1
-    );
+    response = getStatusList(pool_1.address, 1, 0, chain, pool_1);
     let statusList = response.result.expectTuple();
     let members = statusList["status-list"].expectSome().expectList();
     members[0].expectTuple().cycle.expectUint(0);
 
-    // verify status for users with locking period 2
-    lockingPeriod = 2;
-    response = getStatusListsLastIndex(
-      pool_2.address,
-      1,
-      lockingPeriod,
-      chain,
-      deployer
-    );
-    response.result.expectUint(0);
-
-    response = getStatusList(
-      pool_2.address,
-      1,
-      lockingPeriod,
-      0,
-      chain,
-      deployer
-    );
-    statusList = response.result.expectTuple();
-    members = statusList["status-list"].expectSome().expectList();
-    assertEquals(members.length, 1);
-    members[0].expectTuple().cycle.expectUint(0);
-
     // verify that information are based on delegate-stx call only
     // if locking period is more than 1 cycle there is still only one entry
-    response = getStatusList(
-      pool_2.address,
-      2,
-      lockingPeriod,
-      0,
-      chain,
-      deployer
-    );
+    response = getStatusList(pool_2.address, 2, 0, chain, deployer);
     statusList = response.result.expectTuple();
     members = statusList["status-list"].expectNone();
 
@@ -194,7 +146,13 @@ Clarinet.test({
     let info = response.result.expectOk().expectTuple();
     info["stacker-info"].expectTuple()["first-reward-cycle"].expectUint(1);
     info["user-info"].expectTuple().cycle.expectUint(0);
-    info["user-info"].expectTuple()["lock-period"].expectUint(1);
+    info["user-info"]
+      .expectTuple()
+      ["pox-addr"].expectTuple()
+      .hashbytes.expectBuff(
+        hexToBytes("000102030405060708090a0b0c0d0e0f00010203")
+      );
+
     info["total"].expectUint(10_000_000_000_000);
 
     response = getStatus(pool_2.address, wallet_2.address, chain, deployer);
@@ -202,7 +160,13 @@ Clarinet.test({
     info = response.result.expectOk().expectTuple();
     info["stacker-info"].expectTuple()["first-reward-cycle"].expectUint(1);
     info["user-info"].expectTuple().cycle.expectUint(0);
-    info["user-info"].expectTuple()["lock-period"].expectUint(2);
+    info["user-info"]
+      .expectTuple()
+      ["pox-addr"].expectTuple()
+      .hashbytes.expectBuff(
+        hexToBytes("00102030405060708090a0b0c0d0e0f000102030")
+      );
+
     info["total"].expectUint(10_000_000_000_000);
   },
 });
@@ -229,62 +193,17 @@ Clarinet.test({
     block.receipts[1].result.expectOk().expectUint(1);
 
     // verify status for users with locking period 1
-    let lockingPeriod = 1;
-    let response = getStatusListsLastIndex(
-      pool_1.address,
-      1,
-      lockingPeriod,
-      chain,
-      pool_1
-    );
+    let response = getStatusListsLastIndex(pool_1.address, 1, chain, pool_1);
     response.result.expectUint(0);
 
-    response = getStatusList(
-      pool_1.address,
-      1,
-      lockingPeriod,
-      0,
-      chain,
-      pool_1
-    );
+    response = getStatusList(pool_1.address, 1, 0, chain, pool_1);
     let statusList = response.result.expectTuple();
     let members = statusList["status-list"].expectSome().expectList();
     members[0].expectTuple().cycle.expectUint(0);
 
-    // verify status for users with locking period 2
-    lockingPeriod = 2;
-    response = getStatusListsLastIndex(
-      pool_2.address,
-      1,
-      lockingPeriod,
-      chain,
-      deployer
-    );
-    response.result.expectUint(0);
-
-    response = getStatusList(
-      pool_2.address,
-      1,
-      lockingPeriod,
-      0,
-      chain,
-      deployer
-    );
-    statusList = response.result.expectTuple();
-    members = statusList["status-list"].expectSome().expectList();
-    assertEquals(members.length, 1);
-    members[0].expectTuple().cycle.expectUint(0);
-
     // verify that information are based on delegate-stx call only
-    // if locking period is more than 1 cycle there is still only one entry
-    response = getStatusList(
-      pool_2.address,
-      2,
-      lockingPeriod,
-      0,
-      chain,
-      deployer
-    );
+    // there is always only one entry
+    response = getStatusList(pool_2.address, 2, 0, chain, deployer);
     statusList = response.result.expectTuple();
     members = statusList["status-list"].expectNone();
 
@@ -294,7 +213,13 @@ Clarinet.test({
     let info = response.result.expectOk().expectTuple();
     info["stacker-info"].expectTuple()["first-reward-cycle"].expectUint(1);
     info["user-info"].expectTuple().cycle.expectUint(0);
-    info["user-info"].expectTuple()["lock-period"].expectUint(1);
+    info["user-info"]
+      .expectTuple()
+      ["pox-addr"].expectTuple()
+      .hashbytes.expectBuff(
+        hexToBytes("000102030405060708090a0b0c0d0e0f00010203")
+      );
+
     info["total"].expectUint(10_000_000_000_000);
 
     response = getStatus(pool_2.address, wallet_2.address, chain, deployer);
@@ -302,7 +227,13 @@ Clarinet.test({
     info = response.result.expectOk().expectTuple();
     info["stacker-info"].expectTuple()["first-reward-cycle"].expectUint(1);
     info["user-info"].expectTuple().cycle.expectUint(0);
-    info["user-info"].expectTuple()["lock-period"].expectUint(2);
+    info["user-info"]
+      .expectTuple()
+      ["pox-addr"].expectTuple()
+      .hashbytes.expectBuff(
+        hexToBytes("00102030405060708090a0b0c0d0e0f000102030")
+      );
+
     info["total"].expectUint(10_000_000_000_000);
   },
 });

--- a/tests/pox-delegate_status_test.ts
+++ b/tests/pox-delegate_status_test.ts
@@ -16,6 +16,7 @@ import {
   btcAddrWallet2,
   poxAddrPool1,
 } from "./constants.ts";
+import { toBytes, hexToBytes } from "https://esm.sh/@stacks/common";
 
 Clarinet.test({
   name: "Ensure that getStatus returns correct values",
@@ -25,7 +26,6 @@ Clarinet.test({
     let pool_1 = accounts.get("deployer")!;
     let pool_2 = accounts.get("wallet_8")!;
     const poxDelegationContract = pool_1.address + ".pox-delegation";
-    const lockingPeriod = 2;
 
     // info before delegation
     let response = getStatus(pool_1.address, wallet_1.address, chain, wallet_1);
@@ -45,7 +45,6 @@ Clarinet.test({
         undefined,
         undefined,
         btcAddrWallet1,
-        lockingPeriod,
         wallet_1
       ),
       delegateStx(
@@ -54,7 +53,6 @@ Clarinet.test({
         undefined,
         undefined,
         btcAddrWallet2,
-        lockingPeriod,
         wallet_2
       ),
     ]);
@@ -68,7 +66,13 @@ Clarinet.test({
     response.result.expectErr().expectUint(Errors.NoStackerInfo);
 
     response = getUserData(wallet_1.address, chain, wallet_1);
-    response.result.expectSome().expectTuple()["lock-period"].expectUint(2);
+    response.result
+      .expectSome()
+      .expectTuple()
+      ["pox-addr"].expectTuple()
+      .hashbytes.expectBuff(
+        hexToBytes("000102030405060708090a0b0c0d0e0f00010203")
+      );
 
     block = chain.mineBlock([
       delegateStackStx(
@@ -80,7 +84,6 @@ Clarinet.test({
         ],
         poxAddrPool1,
         40,
-        lockingPeriod,
         pool_1
       ),
     ]);
@@ -96,7 +99,13 @@ Clarinet.test({
     info["total"].expectUint(100_000_000);
 
     response = getUserData(wallet_1.address, chain, wallet_1);
-    response.result.expectSome().expectTuple()["lock-period"].expectUint(2);
+    response.result
+      .expectSome()
+      .expectTuple()
+      ["pox-addr"].expectTuple()
+      .hashbytes.expectBuff(
+        hexToBytes("000102030405060708090a0b0c0d0e0f00010203")
+      );
 
     // status after commit
     block = chain.mineBlock([
@@ -113,7 +122,13 @@ Clarinet.test({
     info["total"].expectUint(100_000_000);
 
     response = getUserData(wallet_1.address, chain, wallet_1);
-    response.result.expectSome().expectTuple()["lock-period"].expectUint(2);
+    response.result
+      .expectSome()
+      .expectTuple()
+      ["pox-addr"].expectTuple()
+      .hashbytes.expectBuff(
+        hexToBytes("000102030405060708090a0b0c0d0e0f00010203")
+      );
 
     // get status with wrong pool address
     response = getStatus(pool_2.address, wallet_1.address, chain, wallet_1);
@@ -121,6 +136,12 @@ Clarinet.test({
     info["total"].expectUint(0);
 
     response = getUserData(wallet_1.address, chain, wallet_1);
-    response.result.expectSome().expectTuple()["lock-period"].expectUint(2);
+    response.result
+      .expectSome()
+      .expectTuple()
+      ["pox-addr"].expectTuple()
+      .hashbytes.expectBuff(
+        hexToBytes("000102030405060708090a0b0c0d0e0f00010203")
+      );
   },
 });

--- a/tests/pox-delegate_test.ts
+++ b/tests/pox-delegate_test.ts
@@ -32,7 +32,6 @@ Clarinet.test({
         100,
         undefined,
         { version: "0x01", hashbytes: "0x123456" },
-        2,
         wallet_1
       ),
     ]);
@@ -55,7 +54,6 @@ Clarinet.test({
         100,
         undefined,
         { version: "0x01", hashbytes: "0x123456" },
-        2,
         wallet_1
       ),
     ]);
@@ -86,7 +84,6 @@ Clarinet.test({
           version: "0x01",
           hashbytes: "0xb0b75f408a29c271d107e05d614d0ff439813d02",
         },
-        2,
         wallet_1
       ),
 
@@ -101,7 +98,6 @@ Clarinet.test({
           version: "0x01",
           hashbytes: "0xb0b75f408a29c271d107e05d614d0ff439813d02",
         },
-        2,
         2,
         wallet_2
       ),
@@ -136,7 +132,6 @@ Clarinet.test({
         ],
         poxAddrPool1,
         40,
-        1,
         deployer
       ),
     ]);


### PR DESCRIPTION
This PR
* removes locking-period from all public calls and uses 1 locking cycles for all in pox-delegation